### PR TITLE
Review and address GitHub issue comment

### DIFF
--- a/public/chunks/chunk_000.html
+++ b/public/chunks/chunk_000.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_001.html
+++ b/public/chunks/chunk_001.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_002.html
+++ b/public/chunks/chunk_002.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_003.html
+++ b/public/chunks/chunk_003.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_004.html
+++ b/public/chunks/chunk_004.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_005.html
+++ b/public/chunks/chunk_005.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_006.html
+++ b/public/chunks/chunk_006.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_007.html
+++ b/public/chunks/chunk_007.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_008.html
+++ b/public/chunks/chunk_008.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_009.html
+++ b/public/chunks/chunk_009.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_010.html
+++ b/public/chunks/chunk_010.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_011.html
+++ b/public/chunks/chunk_011.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_012.html
+++ b/public/chunks/chunk_012.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_013.html
+++ b/public/chunks/chunk_013.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_014.html
+++ b/public/chunks/chunk_014.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_015.html
+++ b/public/chunks/chunk_015.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_016.html
+++ b/public/chunks/chunk_016.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_017.html
+++ b/public/chunks/chunk_017.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_018.html
+++ b/public/chunks/chunk_018.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_019.html
+++ b/public/chunks/chunk_019.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_020.html
+++ b/public/chunks/chunk_020.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_021.html
+++ b/public/chunks/chunk_021.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_022.html
+++ b/public/chunks/chunk_022.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_023.html
+++ b/public/chunks/chunk_023.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_024.html
+++ b/public/chunks/chunk_024.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_025.html
+++ b/public/chunks/chunk_025.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_026.html
+++ b/public/chunks/chunk_026.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_027.html
+++ b/public/chunks/chunk_027.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_028.html
+++ b/public/chunks/chunk_028.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_029.html
+++ b/public/chunks/chunk_029.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_030.html
+++ b/public/chunks/chunk_030.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_031.html
+++ b/public/chunks/chunk_031.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_032.html
+++ b/public/chunks/chunk_032.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_033.html
+++ b/public/chunks/chunk_033.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_034.html
+++ b/public/chunks/chunk_034.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_035.html
+++ b/public/chunks/chunk_035.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_036.html
+++ b/public/chunks/chunk_036.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Secrets of Successful Friendships</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_037.html
+++ b/public/chunks/chunk_037.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_038.html
+++ b/public/chunks/chunk_038.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_039.html
+++ b/public/chunks/chunk_039.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_040.html
+++ b/public/chunks/chunk_040.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_041.html
+++ b/public/chunks/chunk_041.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_042.html
+++ b/public/chunks/chunk_042.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_043.html
+++ b/public/chunks/chunk_043.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_044.html
+++ b/public/chunks/chunk_044.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_045.html
+++ b/public/chunks/chunk_045.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_046.html
+++ b/public/chunks/chunk_046.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_047.html
+++ b/public/chunks/chunk_047.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_048.html
+++ b/public/chunks/chunk_048.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_049.html
+++ b/public/chunks/chunk_049.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_050.html
+++ b/public/chunks/chunk_050.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_051.html
+++ b/public/chunks/chunk_051.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_052.html
+++ b/public/chunks/chunk_052.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_053.html
+++ b/public/chunks/chunk_053.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_054.html
+++ b/public/chunks/chunk_054.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_055.html
+++ b/public/chunks/chunk_055.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_056.html
+++ b/public/chunks/chunk_056.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_057.html
+++ b/public/chunks/chunk_057.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_058.html
+++ b/public/chunks/chunk_058.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_059.html
+++ b/public/chunks/chunk_059.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_060.html
+++ b/public/chunks/chunk_060.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_061.html
+++ b/public/chunks/chunk_061.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_062.html
+++ b/public/chunks/chunk_062.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_063.html
+++ b/public/chunks/chunk_063.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_064.html
+++ b/public/chunks/chunk_064.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_065.html
+++ b/public/chunks/chunk_065.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_066.html
+++ b/public/chunks/chunk_066.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_067.html
+++ b/public/chunks/chunk_067.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_068.html
+++ b/public/chunks/chunk_068.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_069.html
+++ b/public/chunks/chunk_069.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_070.html
+++ b/public/chunks/chunk_070.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_071.html
+++ b/public/chunks/chunk_071.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_072.html
+++ b/public/chunks/chunk_072.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_073.html
+++ b/public/chunks/chunk_073.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_074.html
+++ b/public/chunks/chunk_074.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_075.html
+++ b/public/chunks/chunk_075.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_076.html
+++ b/public/chunks/chunk_076.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_077.html
+++ b/public/chunks/chunk_077.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_078.html
+++ b/public/chunks/chunk_078.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_079.html
+++ b/public/chunks/chunk_079.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_080.html
+++ b/public/chunks/chunk_080.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_081.html
+++ b/public/chunks/chunk_081.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_082.html
+++ b/public/chunks/chunk_082.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_083.html
+++ b/public/chunks/chunk_083.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_084.html
+++ b/public/chunks/chunk_084.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_085.html
+++ b/public/chunks/chunk_085.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_086.html
+++ b/public/chunks/chunk_086.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_087.html
+++ b/public/chunks/chunk_087.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_088.html
+++ b/public/chunks/chunk_088.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_089.html
+++ b/public/chunks/chunk_089.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_090.html
+++ b/public/chunks/chunk_090.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_091.html
+++ b/public/chunks/chunk_091.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_092.html
+++ b/public/chunks/chunk_092.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_093.html
+++ b/public/chunks/chunk_093.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_094.html
+++ b/public/chunks/chunk_094.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Varieties of Melancholy</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_095.html
+++ b/public/chunks/chunk_095.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_096.html
+++ b/public/chunks/chunk_096.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_097.html
+++ b/public/chunks/chunk_097.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_098.html
+++ b/public/chunks/chunk_098.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_099.html
+++ b/public/chunks/chunk_099.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_100.html
+++ b/public/chunks/chunk_100.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_101.html
+++ b/public/chunks/chunk_101.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_102.html
+++ b/public/chunks/chunk_102.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_103.html
+++ b/public/chunks/chunk_103.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The Sorrows of Work</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_145.html
+++ b/public/chunks/chunk_145.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_146.html
+++ b/public/chunks/chunk_146.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_147.html
+++ b/public/chunks/chunk_147.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_148.html
+++ b/public/chunks/chunk_148.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_149.html
+++ b/public/chunks/chunk_149.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_150.html
+++ b/public/chunks/chunk_150.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_151.html
+++ b/public/chunks/chunk_151.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_152.html
+++ b/public/chunks/chunk_152.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Deal with Adversity</div>
                 <div class="author">by Christopher Hamilton</div>

--- a/public/chunks/chunk_153.html
+++ b/public/chunks/chunk_153.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_154.html
+++ b/public/chunks/chunk_154.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_155.html
+++ b/public/chunks/chunk_155.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_156.html
+++ b/public/chunks/chunk_156.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_157.html
+++ b/public/chunks/chunk_157.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_158.html
+++ b/public/chunks/chunk_158.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_159.html
+++ b/public/chunks/chunk_159.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_160.html
+++ b/public/chunks/chunk_160.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_161.html
+++ b/public/chunks/chunk_161.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_162.html
+++ b/public/chunks/chunk_162.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_163.html
+++ b/public/chunks/chunk_163.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_164.html
+++ b/public/chunks/chunk_164.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_165.html
+++ b/public/chunks/chunk_165.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_166.html
+++ b/public/chunks/chunk_166.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_167.html
+++ b/public/chunks/chunk_167.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_168.html
+++ b/public/chunks/chunk_168.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_169.html
+++ b/public/chunks/chunk_169.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_170.html
+++ b/public/chunks/chunk_170.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_171.html
+++ b/public/chunks/chunk_171.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_172.html
+++ b/public/chunks/chunk_172.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_173.html
+++ b/public/chunks/chunk_173.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_174.html
+++ b/public/chunks/chunk_174.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_175.html
+++ b/public/chunks/chunk_175.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_176.html
+++ b/public/chunks/chunk_176.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_177.html
+++ b/public/chunks/chunk_177.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_178.html
+++ b/public/chunks/chunk_178.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_179.html
+++ b/public/chunks/chunk_179.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_180.html
+++ b/public/chunks/chunk_180.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_181.html
+++ b/public/chunks/chunk_181.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Travel</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_182.html
+++ b/public/chunks/chunk_182.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_183.html
+++ b/public/chunks/chunk_183.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_184.html
+++ b/public/chunks/chunk_184.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_185.html
+++ b/public/chunks/chunk_185.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_186.html
+++ b/public/chunks/chunk_186.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_187.html
+++ b/public/chunks/chunk_187.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_188.html
+++ b/public/chunks/chunk_188.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_189.html
+++ b/public/chunks/chunk_189.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_190.html
+++ b/public/chunks/chunk_190.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_191.html
+++ b/public/chunks/chunk_191.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_192.html
+++ b/public/chunks/chunk_192.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_193.html
+++ b/public/chunks/chunk_193.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_194.html
+++ b/public/chunks/chunk_194.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_195.html
+++ b/public/chunks/chunk_195.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_196.html
+++ b/public/chunks/chunk_196.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_197.html
+++ b/public/chunks/chunk_197.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_198.html
+++ b/public/chunks/chunk_198.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_199.html
+++ b/public/chunks/chunk_199.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_200.html
+++ b/public/chunks/chunk_200.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_201.html
+++ b/public/chunks/chunk_201.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_202.html
+++ b/public/chunks/chunk_202.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_203.html
+++ b/public/chunks/chunk_203.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How To Connect With Nature (School of Life)</div>
                 <div class="author">by Gooley, Tristan</div>

--- a/public/chunks/chunk_204.html
+++ b/public/chunks/chunk_204.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_205.html
+++ b/public/chunks/chunk_205.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_206.html
+++ b/public/chunks/chunk_206.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_207.html
+++ b/public/chunks/chunk_207.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_208.html
+++ b/public/chunks/chunk_208.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_209.html
+++ b/public/chunks/chunk_209.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_210.html
+++ b/public/chunks/chunk_210.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_211.html
+++ b/public/chunks/chunk_211.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_212.html
+++ b/public/chunks/chunk_212.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_213.html
+++ b/public/chunks/chunk_213.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_214.html
+++ b/public/chunks/chunk_214.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_215.html
+++ b/public/chunks/chunk_215.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_216.html
+++ b/public/chunks/chunk_216.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_217.html
+++ b/public/chunks/chunk_217.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_218.html
+++ b/public/chunks/chunk_218.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_219.html
+++ b/public/chunks/chunk_219.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_220.html
+++ b/public/chunks/chunk_220.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_221.html
+++ b/public/chunks/chunk_221.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_222.html
+++ b/public/chunks/chunk_222.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_223.html
+++ b/public/chunks/chunk_223.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_224.html
+++ b/public/chunks/chunk_224.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_225.html
+++ b/public/chunks/chunk_225.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_226.html
+++ b/public/chunks/chunk_226.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_227.html
+++ b/public/chunks/chunk_227.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_228.html
+++ b/public/chunks/chunk_228.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_229.html
+++ b/public/chunks/chunk_229.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_230.html
+++ b/public/chunks/chunk_230.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_231.html
+++ b/public/chunks/chunk_231.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_232.html
+++ b/public/chunks/chunk_232.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_233.html
+++ b/public/chunks/chunk_233.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_234.html
+++ b/public/chunks/chunk_234.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_235.html
+++ b/public/chunks/chunk_235.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_236.html
+++ b/public/chunks/chunk_236.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_237.html
+++ b/public/chunks/chunk_237.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_238.html
+++ b/public/chunks/chunk_238.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_239.html
+++ b/public/chunks/chunk_239.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_240.html
+++ b/public/chunks/chunk_240.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_241.html
+++ b/public/chunks/chunk_241.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_242.html
+++ b/public/chunks/chunk_242.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_243.html
+++ b/public/chunks/chunk_243.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_244.html
+++ b/public/chunks/chunk_244.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_245.html
+++ b/public/chunks/chunk_245.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_246.html
+++ b/public/chunks/chunk_246.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_247.html
+++ b/public/chunks/chunk_247.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_248.html
+++ b/public/chunks/chunk_248.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_249.html
+++ b/public/chunks/chunk_249.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_250.html
+++ b/public/chunks/chunk_250.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A More Exciting Life: A guide to greater freedom, spontaneity and enjoyment</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_251.html
+++ b/public/chunks/chunk_251.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_252.html
+++ b/public/chunks/chunk_252.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_253.html
+++ b/public/chunks/chunk_253.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_254.html
+++ b/public/chunks/chunk_254.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_255.html
+++ b/public/chunks/chunk_255.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_256.html
+++ b/public/chunks/chunk_256.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_257.html
+++ b/public/chunks/chunk_257.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_258.html
+++ b/public/chunks/chunk_258.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_259.html
+++ b/public/chunks/chunk_259.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_260.html
+++ b/public/chunks/chunk_260.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_261.html
+++ b/public/chunks/chunk_261.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_262.html
+++ b/public/chunks/chunk_262.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_263.html
+++ b/public/chunks/chunk_263.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_264.html
+++ b/public/chunks/chunk_264.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_265.html
+++ b/public/chunks/chunk_265.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_266.html
+++ b/public/chunks/chunk_266.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_267.html
+++ b/public/chunks/chunk_267.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_268.html
+++ b/public/chunks/chunk_268.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_269.html
+++ b/public/chunks/chunk_269.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_270.html
+++ b/public/chunks/chunk_270.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_271.html
+++ b/public/chunks/chunk_271.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_272.html
+++ b/public/chunks/chunk_272.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_273.html
+++ b/public/chunks/chunk_273.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_274.html
+++ b/public/chunks/chunk_274.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_275.html
+++ b/public/chunks/chunk_275.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_276.html
+++ b/public/chunks/chunk_276.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_277.html
+++ b/public/chunks/chunk_277.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_278.html
+++ b/public/chunks/chunk_278.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_279.html
+++ b/public/chunks/chunk_279.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_280.html
+++ b/public/chunks/chunk_280.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_281.html
+++ b/public/chunks/chunk_281.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_282.html
+++ b/public/chunks/chunk_282.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Stay Sane (The School of Life)</div>
                 <div class="author">by Perry, Philippa</div>

--- a/public/chunks/chunk_283.html
+++ b/public/chunks/chunk_283.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_284.html
+++ b/public/chunks/chunk_284.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_285.html
+++ b/public/chunks/chunk_285.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_286.html
+++ b/public/chunks/chunk_286.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_287.html
+++ b/public/chunks/chunk_287.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_288.html
+++ b/public/chunks/chunk_288.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_289.html
+++ b/public/chunks/chunk_289.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_290.html
+++ b/public/chunks/chunk_290.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_291.html
+++ b/public/chunks/chunk_291.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_292.html
+++ b/public/chunks/chunk_292.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_293.html
+++ b/public/chunks/chunk_293.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_294.html
+++ b/public/chunks/chunk_294.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_295.html
+++ b/public/chunks/chunk_295.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_296.html
+++ b/public/chunks/chunk_296.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Bored</div>
                 <div class="author">by Eva Hoffman</div>

--- a/public/chunks/chunk_297.html
+++ b/public/chunks/chunk_297.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_298.html
+++ b/public/chunks/chunk_298.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_299.html
+++ b/public/chunks/chunk_299.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_300.html
+++ b/public/chunks/chunk_300.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_301.html
+++ b/public/chunks/chunk_301.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_302.html
+++ b/public/chunks/chunk_302.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_303.html
+++ b/public/chunks/chunk_303.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_304.html
+++ b/public/chunks/chunk_304.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_305.html
+++ b/public/chunks/chunk_305.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_306.html
+++ b/public/chunks/chunk_306.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_307.html
+++ b/public/chunks/chunk_307.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_308.html
+++ b/public/chunks/chunk_308.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_309.html
+++ b/public/chunks/chunk_309.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_310.html
+++ b/public/chunks/chunk_310.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_311.html
+++ b/public/chunks/chunk_311.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_312.html
+++ b/public/chunks/chunk_312.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_313.html
+++ b/public/chunks/chunk_313.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_314.html
+++ b/public/chunks/chunk_314.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_315.html
+++ b/public/chunks/chunk_315.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_316.html
+++ b/public/chunks/chunk_316.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_317.html
+++ b/public/chunks/chunk_317.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_318.html
+++ b/public/chunks/chunk_318.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_319.html
+++ b/public/chunks/chunk_319.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_320.html
+++ b/public/chunks/chunk_320.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_321.html
+++ b/public/chunks/chunk_321.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_322.html
+++ b/public/chunks/chunk_322.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_323.html
+++ b/public/chunks/chunk_323.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_324.html
+++ b/public/chunks/chunk_324.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_325.html
+++ b/public/chunks/chunk_325.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_326.html
+++ b/public/chunks/chunk_326.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_327.html
+++ b/public/chunks/chunk_327.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_328.html
+++ b/public/chunks/chunk_328.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_329.html
+++ b/public/chunks/chunk_329.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_330.html
+++ b/public/chunks/chunk_330.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_331.html
+++ b/public/chunks/chunk_331.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_332.html
+++ b/public/chunks/chunk_332.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_333.html
+++ b/public/chunks/chunk_333.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_334.html
+++ b/public/chunks/chunk_334.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_335.html
+++ b/public/chunks/chunk_335.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_336.html
+++ b/public/chunks/chunk_336.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_337.html
+++ b/public/chunks/chunk_337.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_338.html
+++ b/public/chunks/chunk_338.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_339.html
+++ b/public/chunks/chunk_339.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_340.html
+++ b/public/chunks/chunk_340.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_341.html
+++ b/public/chunks/chunk_341.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_342.html
+++ b/public/chunks/chunk_342.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_343.html
+++ b/public/chunks/chunk_343.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_344.html
+++ b/public/chunks/chunk_344.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_345.html
+++ b/public/chunks/chunk_345.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_346.html
+++ b/public/chunks/chunk_346.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_347.html
+++ b/public/chunks/chunk_347.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_348.html
+++ b/public/chunks/chunk_348.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_349.html
+++ b/public/chunks/chunk_349.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_350.html
+++ b/public/chunks/chunk_350.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_351.html
+++ b/public/chunks/chunk_351.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_352.html
+++ b/public/chunks/chunk_352.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_353.html
+++ b/public/chunks/chunk_353.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Survive the Modern World</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_365.html
+++ b/public/chunks/chunk_365.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_366.html
+++ b/public/chunks/chunk_366.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_367.html
+++ b/public/chunks/chunk_367.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_368.html
+++ b/public/chunks/chunk_368.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_369.html
+++ b/public/chunks/chunk_369.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_370.html
+++ b/public/chunks/chunk_370.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_371.html
+++ b/public/chunks/chunk_371.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_372.html
+++ b/public/chunks/chunk_372.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_373.html
+++ b/public/chunks/chunk_373.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_374.html
+++ b/public/chunks/chunk_374.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_375.html
+++ b/public/chunks/chunk_375.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_376.html
+++ b/public/chunks/chunk_376.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_377.html
+++ b/public/chunks/chunk_377.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_378.html
+++ b/public/chunks/chunk_378.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_379.html
+++ b/public/chunks/chunk_379.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_380.html
+++ b/public/chunks/chunk_380.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_381.html
+++ b/public/chunks/chunk_381.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_382.html
+++ b/public/chunks/chunk_382.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_383.html
+++ b/public/chunks/chunk_383.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_384.html
+++ b/public/chunks/chunk_384.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_385.html
+++ b/public/chunks/chunk_385.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_386.html
+++ b/public/chunks/chunk_386.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_387.html
+++ b/public/chunks/chunk_387.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_388.html
+++ b/public/chunks/chunk_388.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_389.html
+++ b/public/chunks/chunk_389.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_390.html
+++ b/public/chunks/chunk_390.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_391.html
+++ b/public/chunks/chunk_391.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_392.html
+++ b/public/chunks/chunk_392.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_393.html
+++ b/public/chunks/chunk_393.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_394.html
+++ b/public/chunks/chunk_394.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_395.html
+++ b/public/chunks/chunk_395.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_396.html
+++ b/public/chunks/chunk_396.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">How to Be Alone</div>
                 <div class="author">by Sara Maitland</div>

--- a/public/chunks/chunk_397.html
+++ b/public/chunks/chunk_397.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_398.html
+++ b/public/chunks/chunk_398.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_399.html
+++ b/public/chunks/chunk_399.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_400.html
+++ b/public/chunks/chunk_400.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_401.html
+++ b/public/chunks/chunk_401.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_402.html
+++ b/public/chunks/chunk_402.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_403.html
+++ b/public/chunks/chunk_403.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_404.html
+++ b/public/chunks/chunk_404.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_405.html
+++ b/public/chunks/chunk_405.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_406.html
+++ b/public/chunks/chunk_406.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_407.html
+++ b/public/chunks/chunk_407.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_408.html
+++ b/public/chunks/chunk_408.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_409.html
+++ b/public/chunks/chunk_409.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_410.html
+++ b/public/chunks/chunk_410.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_411.html
+++ b/public/chunks/chunk_411.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_412.html
+++ b/public/chunks/chunk_412.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_413.html
+++ b/public/chunks/chunk_413.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_414.html
+++ b/public/chunks/chunk_414.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_415.html
+++ b/public/chunks/chunk_415.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_416.html
+++ b/public/chunks/chunk_416.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_417.html
+++ b/public/chunks/chunk_417.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_418.html
+++ b/public/chunks/chunk_418.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_419.html
+++ b/public/chunks/chunk_419.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_420.html
+++ b/public/chunks/chunk_420.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_421.html
+++ b/public/chunks/chunk_421.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_422.html
+++ b/public/chunks/chunk_422.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_423.html
+++ b/public/chunks/chunk_423.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_424.html
+++ b/public/chunks/chunk_424.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_425.html
+++ b/public/chunks/chunk_425.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_426.html
+++ b/public/chunks/chunk_426.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_427.html
+++ b/public/chunks/chunk_427.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_428.html
+++ b/public/chunks/chunk_428.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_429.html
+++ b/public/chunks/chunk_429.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_430.html
+++ b/public/chunks/chunk_430.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_431.html
+++ b/public/chunks/chunk_431.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_432.html
+++ b/public/chunks/chunk_432.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_433.html
+++ b/public/chunks/chunk_433.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_434.html
+++ b/public/chunks/chunk_434.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_435.html
+++ b/public/chunks/chunk_435.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_436.html
+++ b/public/chunks/chunk_436.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_437.html
+++ b/public/chunks/chunk_437.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_438.html
+++ b/public/chunks/chunk_438.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_439.html
+++ b/public/chunks/chunk_439.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_440.html
+++ b/public/chunks/chunk_440.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_441.html
+++ b/public/chunks/chunk_441.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_442.html
+++ b/public/chunks/chunk_442.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_443.html
+++ b/public/chunks/chunk_443.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_444.html
+++ b/public/chunks/chunk_444.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_445.html
+++ b/public/chunks/chunk_445.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_446.html
+++ b/public/chunks/chunk_446.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_447.html
+++ b/public/chunks/chunk_447.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_448.html
+++ b/public/chunks/chunk_448.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_449.html
+++ b/public/chunks/chunk_449.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_450.html
+++ b/public/chunks/chunk_450.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_451.html
+++ b/public/chunks/chunk_451.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_452.html
+++ b/public/chunks/chunk_452.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_453.html
+++ b/public/chunks/chunk_453.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_454.html
+++ b/public/chunks/chunk_454.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_455.html
+++ b/public/chunks/chunk_455.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_456.html
+++ b/public/chunks/chunk_456.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_457.html
+++ b/public/chunks/chunk_457.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_458.html
+++ b/public/chunks/chunk_458.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_459.html
+++ b/public/chunks/chunk_459.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_460.html
+++ b/public/chunks/chunk_460.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_461.html
+++ b/public/chunks/chunk_461.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_462.html
+++ b/public/chunks/chunk_462.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_463.html
+++ b/public/chunks/chunk_463.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_464.html
+++ b/public/chunks/chunk_464.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_465.html
+++ b/public/chunks/chunk_465.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_466.html
+++ b/public/chunks/chunk_466.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_467.html
+++ b/public/chunks/chunk_467.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_468.html
+++ b/public/chunks/chunk_468.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">On Failure: How to succeed at defeat</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_469.html
+++ b/public/chunks/chunk_469.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_470.html
+++ b/public/chunks/chunk_470.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_471.html
+++ b/public/chunks/chunk_471.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_472.html
+++ b/public/chunks/chunk_472.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_473.html
+++ b/public/chunks/chunk_473.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_474.html
+++ b/public/chunks/chunk_474.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_475.html
+++ b/public/chunks/chunk_475.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_476.html
+++ b/public/chunks/chunk_476.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_477.html
+++ b/public/chunks/chunk_477.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_478.html
+++ b/public/chunks/chunk_478.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_479.html
+++ b/public/chunks/chunk_479.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_480.html
+++ b/public/chunks/chunk_480.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_481.html
+++ b/public/chunks/chunk_481.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_482.html
+++ b/public/chunks/chunk_482.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_483.html
+++ b/public/chunks/chunk_483.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_484.html
+++ b/public/chunks/chunk_484.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_485.html
+++ b/public/chunks/chunk_485.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_486.html
+++ b/public/chunks/chunk_486.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_487.html
+++ b/public/chunks/chunk_487.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_488.html
+++ b/public/chunks/chunk_488.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_489.html
+++ b/public/chunks/chunk_489.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_490.html
+++ b/public/chunks/chunk_490.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_491.html
+++ b/public/chunks/chunk_491.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_492.html
+++ b/public/chunks/chunk_492.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_493.html
+++ b/public/chunks/chunk_493.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_494.html
+++ b/public/chunks/chunk_494.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_495.html
+++ b/public/chunks/chunk_495.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_496.html
+++ b/public/chunks/chunk_496.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_497.html
+++ b/public/chunks/chunk_497.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_498.html
+++ b/public/chunks/chunk_498.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_499.html
+++ b/public/chunks/chunk_499.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_500.html
+++ b/public/chunks/chunk_500.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_501.html
+++ b/public/chunks/chunk_501.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_502.html
+++ b/public/chunks/chunk_502.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Essential Ideas</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_503.html
+++ b/public/chunks/chunk_503.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_504.html
+++ b/public/chunks/chunk_504.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_505.html
+++ b/public/chunks/chunk_505.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_506.html
+++ b/public/chunks/chunk_506.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_507.html
+++ b/public/chunks/chunk_507.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_508.html
+++ b/public/chunks/chunk_508.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_509.html
+++ b/public/chunks/chunk_509.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_510.html
+++ b/public/chunks/chunk_510.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_511.html
+++ b/public/chunks/chunk_511.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_512.html
+++ b/public/chunks/chunk_512.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_513.html
+++ b/public/chunks/chunk_513.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_514.html
+++ b/public/chunks/chunk_514.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_515.html
+++ b/public/chunks/chunk_515.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_516.html
+++ b/public/chunks/chunk_516.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_517.html
+++ b/public/chunks/chunk_517.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_518.html
+++ b/public/chunks/chunk_518.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_519.html
+++ b/public/chunks/chunk_519.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_520.html
+++ b/public/chunks/chunk_520.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_521.html
+++ b/public/chunks/chunk_521.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_522.html
+++ b/public/chunks/chunk_522.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_523.html
+++ b/public/chunks/chunk_523.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_524.html
+++ b/public/chunks/chunk_524.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_525.html
+++ b/public/chunks/chunk_525.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_526.html
+++ b/public/chunks/chunk_526.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_527.html
+++ b/public/chunks/chunk_527.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_528.html
+++ b/public/chunks/chunk_528.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_529.html
+++ b/public/chunks/chunk_529.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_530.html
+++ b/public/chunks/chunk_530.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_531.html
+++ b/public/chunks/chunk_531.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Procrastination: How to do it well</div>
                 <div class="author">by The School of Life</div>

--- a/public/chunks/chunk_532.html
+++ b/public/chunks/chunk_532.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_533.html
+++ b/public/chunks/chunk_533.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_534.html
+++ b/public/chunks/chunk_534.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_535.html
+++ b/public/chunks/chunk_535.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_536.html
+++ b/public/chunks/chunk_536.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_537.html
+++ b/public/chunks/chunk_537.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_538.html
+++ b/public/chunks/chunk_538.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_539.html
+++ b/public/chunks/chunk_539.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_540.html
+++ b/public/chunks/chunk_540.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_541.html
+++ b/public/chunks/chunk_541.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_542.html
+++ b/public/chunks/chunk_542.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_543.html
+++ b/public/chunks/chunk_543.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_544.html
+++ b/public/chunks/chunk_544.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_545.html
+++ b/public/chunks/chunk_545.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_546.html
+++ b/public/chunks/chunk_546.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_547.html
+++ b/public/chunks/chunk_547.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_548.html
+++ b/public/chunks/chunk_548.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_549.html
+++ b/public/chunks/chunk_549.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_550.html
+++ b/public/chunks/chunk_550.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_551.html
+++ b/public/chunks/chunk_551.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_552.html
+++ b/public/chunks/chunk_552.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_553.html
+++ b/public/chunks/chunk_553.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_554.html
+++ b/public/chunks/chunk_554.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_555.html
+++ b/public/chunks/chunk_555.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_556.html
+++ b/public/chunks/chunk_556.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_557.html
+++ b/public/chunks/chunk_557.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_558.html
+++ b/public/chunks/chunk_558.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_559.html
+++ b/public/chunks/chunk_559.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_560.html
+++ b/public/chunks/chunk_560.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_561.html
+++ b/public/chunks/chunk_561.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_562.html
+++ b/public/chunks/chunk_562.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_563.html
+++ b/public/chunks/chunk_563.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_564.html
+++ b/public/chunks/chunk_564.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_565.html
+++ b/public/chunks/chunk_565.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_566.html
+++ b/public/chunks/chunk_566.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_567.html
+++ b/public/chunks/chunk_567.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_568.html
+++ b/public/chunks/chunk_568.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_569.html
+++ b/public/chunks/chunk_569.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_570.html
+++ b/public/chunks/chunk_570.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_571.html
+++ b/public/chunks/chunk_571.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_572.html
+++ b/public/chunks/chunk_572.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_573.html
+++ b/public/chunks/chunk_573.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_574.html
+++ b/public/chunks/chunk_574.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_575.html
+++ b/public/chunks/chunk_575.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_576.html
+++ b/public/chunks/chunk_576.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_577.html
+++ b/public/chunks/chunk_577.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_578.html
+++ b/public/chunks/chunk_578.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_579.html
+++ b/public/chunks/chunk_579.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_580.html
+++ b/public/chunks/chunk_580.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_581.html
+++ b/public/chunks/chunk_581.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_582.html
+++ b/public/chunks/chunk_582.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_583.html
+++ b/public/chunks/chunk_583.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_584.html
+++ b/public/chunks/chunk_584.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_585.html
+++ b/public/chunks/chunk_585.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_586.html
+++ b/public/chunks/chunk_586.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_587.html
+++ b/public/chunks/chunk_587.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_588.html
+++ b/public/chunks/chunk_588.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_589.html
+++ b/public/chunks/chunk_589.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_590.html
+++ b/public/chunks/chunk_590.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_591.html
+++ b/public/chunks/chunk_591.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_592.html
+++ b/public/chunks/chunk_592.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_593.html
+++ b/public/chunks/chunk_593.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_594.html
+++ b/public/chunks/chunk_594.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_595.html
+++ b/public/chunks/chunk_595.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_596.html
+++ b/public/chunks/chunk_596.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_597.html
+++ b/public/chunks/chunk_597.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_598.html
+++ b/public/chunks/chunk_598.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_599.html
+++ b/public/chunks/chunk_599.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_600.html
+++ b/public/chunks/chunk_600.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_601.html
+++ b/public/chunks/chunk_601.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_602.html
+++ b/public/chunks/chunk_602.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_603.html
+++ b/public/chunks/chunk_603.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_604.html
+++ b/public/chunks/chunk_604.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_605.html
+++ b/public/chunks/chunk_605.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_606.html
+++ b/public/chunks/chunk_606.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_607.html
+++ b/public/chunks/chunk_607.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_608.html
+++ b/public/chunks/chunk_608.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_609.html
+++ b/public/chunks/chunk_609.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_610.html
+++ b/public/chunks/chunk_610.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_611.html
+++ b/public/chunks/chunk_611.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_612.html
+++ b/public/chunks/chunk_612.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_613.html
+++ b/public/chunks/chunk_613.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_614.html
+++ b/public/chunks/chunk_614.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_615.html
+++ b/public/chunks/chunk_615.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_616.html
+++ b/public/chunks/chunk_616.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_617.html
+++ b/public/chunks/chunk_617.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_618.html
+++ b/public/chunks/chunk_618.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_619.html
+++ b/public/chunks/chunk_619.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_620.html
+++ b/public/chunks/chunk_620.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_621.html
+++ b/public/chunks/chunk_621.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_622.html
+++ b/public/chunks/chunk_622.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_623.html
+++ b/public/chunks/chunk_623.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_624.html
+++ b/public/chunks/chunk_624.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_625.html
+++ b/public/chunks/chunk_625.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_626.html
+++ b/public/chunks/chunk_626.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_627.html
+++ b/public/chunks/chunk_627.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_628.html
+++ b/public/chunks/chunk_628.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_629.html
+++ b/public/chunks/chunk_629.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_630.html
+++ b/public/chunks/chunk_630.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_631.html
+++ b/public/chunks/chunk_631.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_632.html
+++ b/public/chunks/chunk_632.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_633.html
+++ b/public/chunks/chunk_633.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_634.html
+++ b/public/chunks/chunk_634.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_635.html
+++ b/public/chunks/chunk_635.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_636.html
+++ b/public/chunks/chunk_636.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_637.html
+++ b/public/chunks/chunk_637.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_638.html
+++ b/public/chunks/chunk_638.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_639.html
+++ b/public/chunks/chunk_639.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_640.html
+++ b/public/chunks/chunk_640.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_641.html
+++ b/public/chunks/chunk_641.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_642.html
+++ b/public/chunks/chunk_642.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_643.html
+++ b/public/chunks/chunk_643.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_644.html
+++ b/public/chunks/chunk_644.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_645.html
+++ b/public/chunks/chunk_645.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_646.html
+++ b/public/chunks/chunk_646.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_647.html
+++ b/public/chunks/chunk_647.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_648.html
+++ b/public/chunks/chunk_648.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_649.html
+++ b/public/chunks/chunk_649.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_650.html
+++ b/public/chunks/chunk_650.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_651.html
+++ b/public/chunks/chunk_651.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_652.html
+++ b/public/chunks/chunk_652.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_653.html
+++ b/public/chunks/chunk_653.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_654.html
+++ b/public/chunks/chunk_654.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_655.html
+++ b/public/chunks/chunk_655.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_656.html
+++ b/public/chunks/chunk_656.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_657.html
+++ b/public/chunks/chunk_657.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_658.html
+++ b/public/chunks/chunk_658.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_659.html
+++ b/public/chunks/chunk_659.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_660.html
+++ b/public/chunks/chunk_660.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_661.html
+++ b/public/chunks/chunk_661.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_662.html
+++ b/public/chunks/chunk_662.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_663.html
+++ b/public/chunks/chunk_663.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_664.html
+++ b/public/chunks/chunk_664.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_665.html
+++ b/public/chunks/chunk_665.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_666.html
+++ b/public/chunks/chunk_666.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_667.html
+++ b/public/chunks/chunk_667.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_668.html
+++ b/public/chunks/chunk_668.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_669.html
+++ b/public/chunks/chunk_669.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_670.html
+++ b/public/chunks/chunk_670.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_671.html
+++ b/public/chunks/chunk_671.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_672.html
+++ b/public/chunks/chunk_672.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_673.html
+++ b/public/chunks/chunk_673.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_674.html
+++ b/public/chunks/chunk_674.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_675.html
+++ b/public/chunks/chunk_675.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_676.html
+++ b/public/chunks/chunk_676.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_677.html
+++ b/public/chunks/chunk_677.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_678.html
+++ b/public/chunks/chunk_678.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_679.html
+++ b/public/chunks/chunk_679.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_680.html
+++ b/public/chunks/chunk_680.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_681.html
+++ b/public/chunks/chunk_681.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_682.html
+++ b/public/chunks/chunk_682.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_683.html
+++ b/public/chunks/chunk_683.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_684.html
+++ b/public/chunks/chunk_684.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_685.html
+++ b/public/chunks/chunk_685.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_686.html
+++ b/public/chunks/chunk_686.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_687.html
+++ b/public/chunks/chunk_687.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_688.html
+++ b/public/chunks/chunk_688.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_689.html
+++ b/public/chunks/chunk_689.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_690.html
+++ b/public/chunks/chunk_690.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_691.html
+++ b/public/chunks/chunk_691.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_692.html
+++ b/public/chunks/chunk_692.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_693.html
+++ b/public/chunks/chunk_693.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_694.html
+++ b/public/chunks/chunk_694.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_695.html
+++ b/public/chunks/chunk_695.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_696.html
+++ b/public/chunks/chunk_696.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_697.html
+++ b/public/chunks/chunk_697.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_698.html
+++ b/public/chunks/chunk_698.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_699.html
+++ b/public/chunks/chunk_699.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_700.html
+++ b/public/chunks/chunk_700.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_701.html
+++ b/public/chunks/chunk_701.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_702.html
+++ b/public/chunks/chunk_702.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_703.html
+++ b/public/chunks/chunk_703.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_704.html
+++ b/public/chunks/chunk_704.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_705.html
+++ b/public/chunks/chunk_705.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_706.html
+++ b/public/chunks/chunk_706.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_707.html
+++ b/public/chunks/chunk_707.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_708.html
+++ b/public/chunks/chunk_708.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_709.html
+++ b/public/chunks/chunk_709.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_710.html
+++ b/public/chunks/chunk_710.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_711.html
+++ b/public/chunks/chunk_711.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_712.html
+++ b/public/chunks/chunk_712.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">The School of Life Dictionary</div>
                 <div class="author">by The School Of Life</div>

--- a/public/chunks/chunk_719.html
+++ b/public/chunks/chunk_719.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_720.html
+++ b/public/chunks/chunk_720.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_721.html
+++ b/public/chunks/chunk_721.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_722.html
+++ b/public/chunks/chunk_722.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_723.html
+++ b/public/chunks/chunk_723.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_724.html
+++ b/public/chunks/chunk_724.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_725.html
+++ b/public/chunks/chunk_725.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_726.html
+++ b/public/chunks/chunk_726.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_727.html
+++ b/public/chunks/chunk_727.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_728.html
+++ b/public/chunks/chunk_728.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_729.html
+++ b/public/chunks/chunk_729.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_730.html
+++ b/public/chunks/chunk_730.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_731.html
+++ b/public/chunks/chunk_731.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_732.html
+++ b/public/chunks/chunk_732.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_733.html
+++ b/public/chunks/chunk_733.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_734.html
+++ b/public/chunks/chunk_734.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_735.html
+++ b/public/chunks/chunk_735.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_736.html
+++ b/public/chunks/chunk_736.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_737.html
+++ b/public/chunks/chunk_737.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_738.html
+++ b/public/chunks/chunk_738.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_739.html
+++ b/public/chunks/chunk_739.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_740.html
+++ b/public/chunks/chunk_740.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_741.html
+++ b/public/chunks/chunk_741.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_742.html
+++ b/public/chunks/chunk_742.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_743.html
+++ b/public/chunks/chunk_743.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_744.html
+++ b/public/chunks/chunk_744.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_745.html
+++ b/public/chunks/chunk_745.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_746.html
+++ b/public/chunks/chunk_746.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">Anxiety</div>
                 <div class="author">by The School Of Life.</div>

--- a/public/chunks/chunk_747.html
+++ b/public/chunks/chunk_747.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_748.html
+++ b/public/chunks/chunk_748.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_749.html
+++ b/public/chunks/chunk_749.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_750.html
+++ b/public/chunks/chunk_750.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_751.html
+++ b/public/chunks/chunk_751.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_752.html
+++ b/public/chunks/chunk_752.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_753.html
+++ b/public/chunks/chunk_753.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_754.html
+++ b/public/chunks/chunk_754.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_755.html
+++ b/public/chunks/chunk_755.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_756.html
+++ b/public/chunks/chunk_756.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_757.html
+++ b/public/chunks/chunk_757.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_758.html
+++ b/public/chunks/chunk_758.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_759.html
+++ b/public/chunks/chunk_759.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_760.html
+++ b/public/chunks/chunk_760.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_761.html
+++ b/public/chunks/chunk_761.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_762.html
+++ b/public/chunks/chunk_762.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_763.html
+++ b/public/chunks/chunk_763.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_764.html
+++ b/public/chunks/chunk_764.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_765.html
+++ b/public/chunks/chunk_765.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_766.html
+++ b/public/chunks/chunk_766.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_767.html
+++ b/public/chunks/chunk_767.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_768.html
+++ b/public/chunks/chunk_768.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_769.html
+++ b/public/chunks/chunk_769.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_770.html
+++ b/public/chunks/chunk_770.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_771.html
+++ b/public/chunks/chunk_771.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_772.html
+++ b/public/chunks/chunk_772.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_773.html
+++ b/public/chunks/chunk_773.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_774.html
+++ b/public/chunks/chunk_774.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_775.html
+++ b/public/chunks/chunk_775.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_776.html
+++ b/public/chunks/chunk_776.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_777.html
+++ b/public/chunks/chunk_777.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_778.html
+++ b/public/chunks/chunk_778.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_779.html
+++ b/public/chunks/chunk_779.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_780.html
+++ b/public/chunks/chunk_780.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_781.html
+++ b/public/chunks/chunk_781.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_782.html
+++ b/public/chunks/chunk_782.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_783.html
+++ b/public/chunks/chunk_783.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_784.html
+++ b/public/chunks/chunk_784.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_785.html
+++ b/public/chunks/chunk_785.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_786.html
+++ b/public/chunks/chunk_786.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_787.html
+++ b/public/chunks/chunk_787.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_788.html
+++ b/public/chunks/chunk_788.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_789.html
+++ b/public/chunks/chunk_789.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_790.html
+++ b/public/chunks/chunk_790.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_791.html
+++ b/public/chunks/chunk_791.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_792.html
+++ b/public/chunks/chunk_792.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_793.html
+++ b/public/chunks/chunk_793.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_794.html
+++ b/public/chunks/chunk_794.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_795.html
+++ b/public/chunks/chunk_795.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_796.html
+++ b/public/chunks/chunk_796.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_797.html
+++ b/public/chunks/chunk_797.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_798.html
+++ b/public/chunks/chunk_798.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_799.html
+++ b/public/chunks/chunk_799.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_800.html
+++ b/public/chunks/chunk_800.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_801.html
+++ b/public/chunks/chunk_801.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_802.html
+++ b/public/chunks/chunk_802.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_803.html
+++ b/public/chunks/chunk_803.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_804.html
+++ b/public/chunks/chunk_804.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_805.html
+++ b/public/chunks/chunk_805.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_806.html
+++ b/public/chunks/chunk_806.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_807.html
+++ b/public/chunks/chunk_807.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_808.html
+++ b/public/chunks/chunk_808.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_809.html
+++ b/public/chunks/chunk_809.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_810.html
+++ b/public/chunks/chunk_810.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_811.html
+++ b/public/chunks/chunk_811.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_812.html
+++ b/public/chunks/chunk_812.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_813.html
+++ b/public/chunks/chunk_813.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_814.html
+++ b/public/chunks/chunk_814.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/public/chunks/chunk_815.html
+++ b/public/chunks/chunk_815.html
@@ -9,7 +9,7 @@
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
         .container { max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }
         .header { border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }
-        .back-link { color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }
+        .back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }
         .back-link:hover { text-decoration: underline; }
         .book-info { margin-bottom: 10px; }
         .book-title { font-size: 24px; font-weight: bold; color: #000; }
@@ -40,7 +40,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) { history.back(); } else { window.location.href = '../../index.html'; }" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">A Therapeutic Journey</div>
                 <div class="author">by Alain de Botton</div>

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -252,7 +252,7 @@ def generate_chunk_pages(chunks):
         body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }}
         .container {{ max-width: 800px; margin: 0 auto; padding: 20px; background: white; min-height: 100vh; }}
         .header {{ border-bottom: 2px solid #e0e0e0; padding-bottom: 20px; margin-bottom: 30px; }}
-        .back-link {{ color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; }}
+        .back-link {{ color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }}
         .back-link:hover {{ text-decoration: underline; }}
         .book-info {{ margin-bottom: 10px; }}
         .book-title {{ font-size: 24px; font-weight: bold; color: #000; }}
@@ -283,7 +283,7 @@ def generate_chunk_pages(chunks):
 <body>
     <div class="container">
         <div class="header">
-            <a href="../../index.html" class="back-link">← Back to Search</a>
+            <button onclick="if (document.referrer.includes('/essay_search_engine/') || document.referrer.includes('localhost')) {{ history.back(); }} else {{ window.location.href = '../../index.html'; }}" class="back-link">← Back to Search</button>
             <div class="book-info">
                 <div class="book-title">{chunk['book_title']}</div>
                 <div class="author">by {chunk['author']}</div>

--- a/update_chunks.py
+++ b/update_chunks.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Bulk update script to fix the "Back to Search" button in all existing chunk HTML files.
+
+This script updates:
+1. The CSS styling for .back-link (to support button element)
+2. The HTML element from <a> tag to <button> with history.back() fallback logic
+"""
+
+import re
+from pathlib import Path
+
+def update_chunk_file(file_path):
+    """Update a single chunk HTML file with the new back button."""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    original_content = content
+
+    # Update 1: Fix CSS for .back-link to support button element
+    old_css = r'\.back-link \{ color: #0066cc; text-decoration: none; font-size: 14px; display: inline-block; margin-bottom: 15px; \}'
+    new_css = '.back-link { color: #0066cc; background: none; border: none; font-size: 14px; display: inline-block; margin-bottom: 15px; cursor: pointer; padding: 0; font-family: inherit; }'
+    content = re.sub(old_css, new_css, content)
+
+    # Update 2: Replace <a> tag with <button> and add history.back() logic
+    old_html = r'<a href="../../index\.html" class="back-link">← Back to Search</a>'
+    new_html = '<button onclick="if (document.referrer.includes(\'/essay_search_engine/\') || document.referrer.includes(\'localhost\')) { history.back(); } else { window.location.href = \'../../index.html\'; }" class="back-link">← Back to Search</button>'
+    content = re.sub(old_html, new_html, content)
+
+    # Only write if changes were made
+    if content != original_content:
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return True
+    return False
+
+def main():
+    """Main function to process all chunk files."""
+    chunks_dir = Path(__file__).parent / 'public' / 'chunks'
+
+    if not chunks_dir.exists():
+        print(f"❌ Error: Chunks directory not found at {chunks_dir}")
+        return
+
+    # Find all chunk HTML files
+    chunk_files = sorted(chunks_dir.glob('chunk_*.html'))
+
+    if not chunk_files:
+        print(f"❌ No chunk files found in {chunks_dir}")
+        return
+
+    print(f"📄 Found {len(chunk_files)} chunk files to update...")
+
+    updated_count = 0
+    for i, file_path in enumerate(chunk_files):
+        if update_chunk_file(file_path):
+            updated_count += 1
+
+        # Progress indicator every 50 files
+        if (i + 1) % 50 == 0:
+            print(f"   Processed {i + 1}/{len(chunk_files)} files...")
+
+    print(f"\n✓ Successfully updated {updated_count} out of {len(chunk_files)} files")
+
+    if updated_count < len(chunk_files):
+        print(f"ℹ️  {len(chunk_files) - updated_count} files were already up to date")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Resolves issue #2 by replacing static link with history.back() button.

Changes:
- Updated sync/sync.py template: Changed <a> tag to <button> with smart navigation
- Updated CSS: Added button-specific styles (cursor, border, background, padding)
- Updated all 758 chunk HTML files with new back button
- Added fallback: Uses history.back() if from site, else returns to index

The button now preserves search results, query text, and scroll position when navigating back from chunk detail pages. Falls back to home page when accessed directly via bookmark or external link.